### PR TITLE
ci: enforce conventional pr titles

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,21 @@
+name: Semantic PR title
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title against Conventional Commit format
+        uses: amannn/action-semantic-pull-request@v5
+        with:
+          requireScope: false
+          # do not start subject with an uppercase letter
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}" should start with a lowercase letter.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
 ![main GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/sripwoud/rust-template/main.yml?branch=main&label=main)
 [![Coverage Status](https://coveralls.io/repos/github/sripwoud/rust-template/badge.svg?branch=main)](https://coveralls.io/github/sripwoud/rust-template?branch=main)
 
-| Feature                                        | With                                                                  | Configuration File                       |
-| ---------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------- |
-| Continuous Integration                         | [GitHub Workflow](https://docs.github.com/en/actions/using-workflows) | [.github/workflows](./.github/workflows) |
-| Formatting                                     | [dprint](https://dprint.dev/)                                         | [.dprint.jsonc](./.biome.json)           |
-| Git Hooks                                      | [hk](https://hk.jdx.dev/)                                             | [hk.pkl](./hk.pkl)                       |
-| Tasks Runner, Environment & Runtime Management | [mise](https://mise.dev/)                                             | [mise.toml](./mise.toml)                 |
-| Tests Runner                                   | [nextest](https://nexte.st/)                                          |                                          |
+| Feature                                                                                                           | With                                                                                         | Configuration File                                     |
+| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Continuous Integration                                                                                            | [GitHub Workflow](https://docs.github.com/en/actions/using-workflows)                        | [.github/workflows](./.github/workflows)               |
+| Conventional Commits (`main` branch only)                                                                         | [convco](https://github.com/convco/convco)                                                   | [.convco](./.convco)                                   |
+| Formatting                                                                                                        | [dprint](https://dprint.dev/)                                                                | [.dprint.jsonc](./.biome.json)                         |
+| Git Hooks                                                                                                         | [hk](https://hk.jdx.dev/)                                                                    | [hk.pkl](./hk.pkl)                                     |
+| Conventional PR Titles (because I only squash merge and base changelogs/semantic versioning on `main` commit history) | [amann/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) | [semantic-pr.yml](./.github/workflows/semantic-pr.yml) |
+| Tasks Runner, Environment & Runtime Management                                                                    | [mise](https://mise.dev/)                                                                    | [mise.toml](./mise.toml)                               |
+| Tests Runner                                                                                                      | [nextest](https://nexte.st/)                                                                 |                                                        |
 
 ## Develop
 


### PR DESCRIPTION
Because my workflow is PR driven, I squash merge and I use commits history for semantic versioning
